### PR TITLE
Make all record fields pointers in preparation for partial_update

### DIFF
--- a/internal/codegen/record.go
+++ b/internal/codegen/record.go
@@ -42,7 +42,7 @@ func (r *Record) field(f Field) *Statement {
 }
 
 func (f *Field) IsPointer() bool {
-	return (f.IsOptional || f.DefaultValue != nil) && !f.Type.IsMapOrArray()
+	return !f.Type.IsUnion() && !f.Type.IsMapOrArray()
 }
 
 func (r *Record) generateStruct() *Statement {
@@ -58,7 +58,7 @@ func (r *Record) generateStruct() *Statement {
 				field.Add(f.Type.GoType())
 			}
 
-			field.Tag(JsonFieldTag(f.Name, f.IsOptional || f.DefaultValue != nil))
+			field.Tag(JsonFieldTag(f.Name, true))
 		}
 	})
 }

--- a/internal/codegen/type.go
+++ b/internal/codegen/type.go
@@ -97,6 +97,10 @@ func (t *RestliType) ReferencedType() *Statement {
 	return t.PointerType()
 }
 
+func (t *RestliType) IsUnion() bool {
+	return t.Union != nil
+}
+
 func (t *RestliType) IsMapOrArray() bool {
 	return t.Array != nil || t.Map != nil || (t.Primitive != nil && t.Primitive.IsBytes())
 }

--- a/internal/tests/actionSet_test.go
+++ b/internal/tests/actionSet_test.go
@@ -11,7 +11,7 @@ import (
 
 func (s *TestServer) ActionsetEcho(t *testing.T, c Client) {
 	input := "Is anybody out there?"
-	output, err := c.EchoAction(&EchoActionParams{Input: input})
+	output, err := c.EchoAction(&EchoActionParams{Input: &input})
 	require.NoError(t, err)
 	require.Equal(t, &input, output, "Invalid response from server")
 }
@@ -31,16 +31,19 @@ func (s *TestServer) ActionsetReturnBool(t *testing.T, c Client) {
 }
 
 func (s *TestServer) ActionsetEchoMessage(t *testing.T, c Client) {
-	message := conflictresolution.Message{Message: "test message"}
-	res, err := c.EchoMessageAction(&EchoMessageActionParams{Message: message})
+	msg := "test message"
+	message := conflictresolution.Message{Message: &msg}
+	res, err := c.EchoMessageAction(&EchoMessageActionParams{Message: &message})
 	require.NoError(t, err)
 	require.Equal(t, &message, res, "Invalid response from server")
 }
 
 func (s *TestServer) ActionsetEchoMessageArray(t *testing.T, c Client) {
+	msg1 := "test message"
+	msg2 := "another message"
 	messageArray := []*conflictresolution.Message{
-		{Message: "test message"},
-		{Message: "another message"},
+		{Message: &msg1},
+		{Message: &msg2},
 	}
 	res, err := c.EchoMessageArrayAction(&EchoMessageArrayActionParams{Messages: messageArray})
 	require.NoError(t, err)
@@ -66,18 +69,18 @@ func (s *TestServer) ActionsetEchoStringMap(t *testing.T, c Client) {
 
 func (s *TestServer) ActionsetEchoTyperefUrl(t *testing.T, c Client) {
 	var urlTyperef testsuite.Url = "http://rest.li"
-	res, err := c.EchoTyperefUrlAction(&EchoTyperefUrlActionParams{UrlTyperef: urlTyperef})
+	res, err := c.EchoTyperefUrlAction(&EchoTyperefUrlActionParams{UrlTyperef: &urlTyperef})
 	require.NoError(t, err)
 	require.Equal(t, urlTyperef, *res, "Invalid response from server")
 }
 
 func (s *TestServer) ActionsetEchoPrimitiveUnion(t *testing.T, c Client) {
 	union := &testsuite.UnionOfPrimitives{}
-	union.InitializePrimitivesUnion()
+	//union.InitializePrimitivesUnion()
 	union.PrimitivesUnion.Long = new(int64)
 	*union.PrimitivesUnion.Long = 100
 
-	res, err := c.EchoPrimitiveUnionAction(&EchoPrimitiveUnionActionParams{PrimitiveUnion: *union})
+	res, err := c.EchoPrimitiveUnionAction(&EchoPrimitiveUnionActionParams{PrimitiveUnion: union})
 	require.NoError(t, err)
 	require.Equal(t, *union, *res, "Invalid response from server")
 }
@@ -87,25 +90,30 @@ func (s *TestServer) ActionsetEchoComplexTypesUnion(t *testing.T, c Client) {
 	union.ComplexTypeUnion.Fruits = new(conflictresolution.Fruits)
 	*union.ComplexTypeUnion.Fruits = conflictresolution.Fruits_APPLE
 
-	res, err := c.EchoComplexTypesUnionAction(&EchoComplexTypesUnionActionParams{ComplexTypesUnion: *union})
+	res, err := c.EchoComplexTypesUnionAction(&EchoComplexTypesUnionActionParams{ComplexTypesUnion: union})
 	require.NoError(t, err)
 	require.Equal(t, *union, *res, "Invalid response from server")
 }
 
 func (s *TestServer) ActionsetEmptyResponse(t *testing.T, c Client) {
+	msg1 := "test message"
+	msg2 := "another message"
 	err := c.EmptyResponseAction(&EmptyResponseActionParams{
-		Message1: conflictresolution.Message{Message: "test message"},
-		Message2: conflictresolution.Message{Message: "another message"},
+		Message1: &conflictresolution.Message{Message: &msg1},
+		Message2: &conflictresolution.Message{Message: &msg2},
 	})
 	require.NoError(t, err)
 }
 
 func (s *TestServer) ActionsetMultipleInputs(t *testing.T, c Client) {
 	optionalString := "optional string"
+	str := "string"
+	url := testsuite.Url("http://rest.li")
+	msg := "test message"
 	res, err := c.MultipleInputsAction(&MultipleInputsActionParams{
-		String:         "string",
-		Message:        conflictresolution.Message{Message: "test message"},
-		UrlTyperef:     "http://rest.li",
+		String:         &str,
+		Message:        &conflictresolution.Message{Message: &msg},
+		UrlTyperef:     &url,
 		OptionalString: &optionalString,
 	})
 	require.NoError(t, err)
@@ -113,10 +121,13 @@ func (s *TestServer) ActionsetMultipleInputs(t *testing.T, c Client) {
 }
 
 func (s *TestServer) ActionsetMultipleInputsNoOptional(t *testing.T, c Client) {
+	str := "string"
+	url := testsuite.Url("http//rest.li")
+	msg := "test message"
 	res, err := c.MultipleInputsAction(&MultipleInputsActionParams{
-		String:     "string",
-		Message:    conflictresolution.Message{Message: "test message"},
-		UrlTyperef: "http//rest.li",
+		String:     &str,
+		Message:    &conflictresolution.Message{Message: &msg},
+		UrlTyperef: &url,
 	})
 	require.NoError(t, err)
 	require.True(t, *res, "Invalid response from server")

--- a/internal/tests/collection_test.go
+++ b/internal/tests/collection_test.go
@@ -51,11 +51,13 @@ func (s *TestServer) SubCollectionOfCollectionGet(t *testing.T, c Client) {
 func (s *TestServer) SubSimpleOfCollectionGet(t *testing.T, c Client) {
 	res, err := colletionSubSimple.NewClient(s.client).Get(1)
 	require.NoError(t, err)
-	require.Equal(t, &conflictresolution.Message{Message: "sub simple message"}, res, "Invalid response from server")
+	msg := "sub simple message"
+	require.Equal(t, &conflictresolution.Message{Message: &msg}, res, "Invalid response from server")
 }
 
 func (s *TestServer) CollectionSearchFinder(t *testing.T, c Client) {
-	params := &FindBySearchParams{Keyword: "message"}
+	keyword := "message"
+	params := &FindBySearchParams{Keyword: &keyword}
 	expectedMessages := []*conflictresolution.Message{newMessage(1, "test message"), newMessage(2, "another message")}
 	res, err := c.FindBySearch(params)
 	require.NoError(t, err)
@@ -65,6 +67,6 @@ func (s *TestServer) CollectionSearchFinder(t *testing.T, c Client) {
 func newMessage(id int64, message string) *conflictresolution.Message {
 	return &conflictresolution.Message{
 		Id:      &id,
-		Message: message,
+		Message: &message,
 	}
 }

--- a/internal/tests/simple_test.go
+++ b/internal/tests/simple_test.go
@@ -11,11 +11,13 @@ import (
 func (s *TestServer) SimpleGet(t *testing.T, c Client) {
 	res, err := c.Get()
 	require.NoError(t, err)
-	require.Equal(t, "test message", res.Message, "Invalid response from server")
+	msg := "test message"
+	require.Equal(t, &msg, res.Message, "Invalid response from server")
 }
 
 func (s *TestServer) SimpleUpdate(t *testing.T, c Client) {
-	err := c.Update(&conflictresolution.Message{Message: "updated message"})
+	msg := "updated message"
+	err := c.Update(&conflictresolution.Message{Message: &msg})
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
I've been looking at how to implement support for `partial_update` and there has to be a way to serialize the `$set` structure of a patch without populating values for required fields as it would update those fields as well. For example:
```go
type Person struct {
  Name string `json:"name"`
  HasPet *bool `json:"hasPet,omitempty"`
}
```
If a `PartialUpdate(&Person{HasPet: &hasPet})` method is implemented and it serializes the Person object into a rest.li patch it will look like this:
```json
{
  "patch": {
    "$set": {
      "name": "",
      "hasPet": true,
    }
  }
}
```
This would _also_ set the `name` field to an empty string when the user only wanted to update the `hasPet` field. The trade-off becomes losing some usability for other methods or falling back to reflection to handle the patch sets. 

This patch makes all JSON tags "omitempty" and all struct fields pointers unless they are a Union type (which I haven't figured out how best to support yet) or a map/slice which have a builtin `nil` value. This should be a major version bump when tagged as it changes the structure of existing structs.