### PR TITLE
Added _Partial, _Fields, and _Patch structs for all records

### DIFF
--- a/internal/codegen/codefile.go
+++ b/internal/codegen/codefile.go
@@ -15,9 +15,6 @@ import (
 )
 
 const (
-	Strings = "strings"
-	Join    = "Join"
-
 	EncodingJson  = "encoding/json"
 	Unmarshal     = "Unmarshal"
 	UnmarshalJSON = "UnmarshalJSON"
@@ -25,6 +22,7 @@ const (
 	MarshalJSON   = "MarshalJSON"
 
 	Codec                = "codec"
+	RestLiHeaderID       = "RestLiHeader_ID"
 	RestLiEncode         = "RestLiEncode"
 	RestLiDecode         = "RestLiDecode"
 	RestLiCodec          = "RestLiCodec"
@@ -34,9 +32,9 @@ const (
 	PopulateDefaultValues = "populateDefaultValues"
 	ValidateUnionFields   = "validateUnionFields"
 
-	GatherFields = "GatherFields"
-	FieldsParam  = "fields"
-	PrefixParam  = "prefix"
+	Selected    = "Selected"
+	SelectedVar = "selected"
+	FieldVar    = "field"
 
 	NetHttp = "net/http"
 

--- a/internal/codegen/codefile.go
+++ b/internal/codegen/codefile.go
@@ -15,6 +15,9 @@ import (
 )
 
 const (
+	Strings = "strings"
+	Join    = "Join"
+
 	EncodingJson  = "encoding/json"
 	Unmarshal     = "Unmarshal"
 	UnmarshalJSON = "UnmarshalJSON"
@@ -30,6 +33,10 @@ const (
 
 	PopulateDefaultValues = "populateDefaultValues"
 	ValidateUnionFields   = "validateUnionFields"
+
+	GatherFields = "GatherFields"
+	FieldsParam  = "fields"
+	PrefixParam  = "prefix"
 
 	NetHttp = "net/http"
 

--- a/internal/codegen/union.go
+++ b/internal/codegen/union.go
@@ -28,6 +28,17 @@ func (u *UnionType) GoType() *Statement {
 	})
 }
 
+func (u *UnionType) FieldGoType() *Statement {
+	return StructFunc(func(def *Group) {
+		for _, m := range *u {
+			field := def.Empty()
+			field.Id(m.name())
+			field.Add(m.Type.FieldGoType())
+			field.Tag(JsonFieldTag(m.Alias, true))
+		}
+	})
+}
+
 func (u *UnionType) validateUnionFields(def *Group, accessor *Statement) {
 	isSet := "is" + canonicalizeAccessor(accessor) + "Set"
 	def.Id(isSet).Op(":=").False().Line()

--- a/internal/codegen/union.go
+++ b/internal/codegen/union.go
@@ -28,17 +28,6 @@ func (u *UnionType) GoType() *Statement {
 	})
 }
 
-func (u *UnionType) FieldGoType() *Statement {
-	return StructFunc(func(def *Group) {
-		for _, m := range *u {
-			field := def.Empty()
-			field.Id(m.name())
-			field.Add(m.Type.FieldGoType())
-			field.Tag(JsonFieldTag(m.Alias, true))
-		}
-	})
-}
-
 func (u *UnionType) validateUnionFields(def *Group, accessor *Statement) {
 	isSet := "is" + canonicalizeAccessor(accessor) + "Set"
 	def.Id(isSet).Op(":=").False().Line()


### PR DESCRIPTION
Adds `_Partial`, `_Fields` and `_Patch` structs for each record type, ex:
```
type Address struct {
	Street string `json:"street"`
}

type Address_Partial struct {
	Street *string `json:"street,omitempty"`
}

type Address_Fields struct {
	Street bool
}

type Address_Patch struct {
	Set    *Address_Partial
	Delete Address_Fields
}
```
The `_Fields` struct implement a custom `Stringer` and `json.Marshaller` interface which converts the `true` fields into a `[]string`. 

To accomplish this with minimal allocations, a new exported method `GatherFields(prefix string, fields *[]string)` is added to all `_Fields` structs which adds each set field to `fields` with `prefix`. Internally if a `_Fields` struct contains another `_Fields` struct the `GatherFields` method is used. The method must be exported to support conflict resolution/cross package nested Fields.

There are no tests added in this PR as this is just field/struct generation, usage of the structs will require tests.