### PR TITLE
Implement "create" method

### DIFF
--- a/internal/codegen/codefile.go
+++ b/internal/codegen/codefile.go
@@ -22,6 +22,7 @@ const (
 	MarshalJSON   = "MarshalJSON"
 
 	Codec                = "codec"
+	RestLiHeaderID       = "RestLiHeader_ID"
 	RestLiEncode         = "RestLiEncode"
 	RestLiDecode         = "RestLiDecode"
 	RestLiCodec          = "RestLiCodec"

--- a/internal/codegen/decode.go
+++ b/internal/codegen/decode.go
@@ -1,0 +1,28 @@
+package codegen
+
+import (
+	. "github.com/dave/jennifer/jen"
+)
+
+func (t *RestliType) RestLiURLDecodeModel(input *Statement, output *Statement) (def *Statement, hasError bool) {
+	return t.RestLiDecodeModel(RestLiUrlEncoder, input, output)
+}
+
+func (t *RestliType) RestLiReducedDecodeModel(input *Statement, output *Statement) (def *Statement, hasError bool) {
+	return t.RestLiDecodeModel(RestLiReducedEncoder, input, output)
+}
+
+func (t *RestliType) RestLiDecodeModel(encoder string, input *Statement, output *Statement) (*Statement, bool) {
+	decoderRef := Qual(ProtocolPackage, encoder)
+
+	if t.Reference != nil {
+		return Add(output).Dot(RestLiDecode).Call(decoderRef, input), true
+	}
+
+	if t.Primitive != nil {
+		return Add(decoderRef).Dot("Decode"+ExportedIdentifier(t.Primitive.Type)).Call(input, output), true
+	}
+
+	Logger.Panicf("%+v cannot be url decoded", t)
+	return nil, false
+}

--- a/internal/codegen/method.go
+++ b/internal/codegen/method.go
@@ -13,14 +13,15 @@ const (
 )
 
 type Method struct {
-	MethodType MethodType
-	Name       string
-	Doc        string
-	Path       string
-	OnEntity   bool
-	PathKeys   []PathKey
-	Params     []Field
-	Return     *RestliType
+	MethodType    MethodType
+	Name          string
+	Doc           string
+	Path          string
+	OnEntity      bool
+	EntityPathKey *PathKey
+	PathKeys      []PathKey
+	Params        []Field
+	Return        *RestliType
 }
 
 type PathKey struct {

--- a/internal/codegen/primitive.go
+++ b/internal/codegen/primitive.go
@@ -11,16 +11,17 @@ import (
 type PrimitiveType struct {
 	Type        string
 	newInstance func() interface{}
+	empty       interface{}
 }
 
 var PrimitiveTypes = []PrimitiveType{
-	{Type: "int32", newInstance: func() interface{} { return new(int32) }},
-	{Type: "int64", newInstance: func() interface{} { return new(int64) }},
-	{Type: "float32", newInstance: func() interface{} { return new(float32) }},
-	{Type: "float64", newInstance: func() interface{} { return new(float64) }},
-	{Type: "bool", newInstance: func() interface{} { return new(bool) }},
-	{Type: "string", newInstance: func() interface{} { return new(string) }},
-	{Type: "bytes", newInstance: func() interface{} { return new([]byte) }},
+	{Type: "int32", newInstance: func() interface{} { return new(int32) }, empty: int32(0)},
+	{Type: "int64", newInstance: func() interface{} { return new(int64) }, empty: int64(0)},
+	{Type: "float32", newInstance: func() interface{} { return new(float32) }, empty: float32(0.0)},
+	{Type: "float64", newInstance: func() interface{} { return new(float64) }, empty: float64(0.0)},
+	{Type: "bool", newInstance: func() interface{} { return new(bool) }, empty: false},
+	{Type: "string", newInstance: func() interface{} { return new(string) }, empty: ""},
+	{Type: "bytes", newInstance: func() interface{} { return new([]byte) }, empty: nil},
 }
 
 func (p *PrimitiveType) UnmarshalJSON(data []byte) error {
@@ -41,6 +42,10 @@ func (p *PrimitiveType) UnmarshalJSON(data []byte) error {
 
 func (p *PrimitiveType) IsBytes() bool {
 	return p.Type == "bytes"
+}
+
+func (p *PrimitiveType) Nil() *Statement {
+	return Lit(p.empty)
 }
 
 func (p *PrimitiveType) Cast(accessor *Statement) *Statement {

--- a/internal/codegen/type.go
+++ b/internal/codegen/type.go
@@ -25,6 +25,15 @@ type RestliType struct {
 	Union     *UnionType
 }
 
+func (t *RestliType) Nil() *Statement {
+	switch {
+	case t.Primitive != nil:
+		return t.Primitive.Nil()
+	default:
+		return Nil()
+	}
+}
+
 func (t *RestliType) UnmarshalJSON(data []byte) error {
 	type _t RestliType
 	err := json.Unmarshal(data, (*_t)(t))

--- a/internal/tests/collection_test.go
+++ b/internal/tests/collection_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func (s *TestServer) CollectionCreate(t *testing.T, c Client) {
+	id, err := c.Create(&conflictresolution.Message{
+		Message: "test message",
+	})
+	require.NoError(t, err)
+	require.Equal(t, id, int64(1))
+}
+
 func (s *TestServer) CollectionGet(t *testing.T, c Client) {
 	id := int64(1)
 	res, err := c.Get(id)

--- a/protocol/http.go
+++ b/protocol/http.go
@@ -16,6 +16,7 @@ import (
 const (
 	RestLiProtocolVersion = "2.0.0"
 
+	RestLiHeader_ID              = "X-RestLi-Id"
 	RestLiHeader_Method          = "X-RestLi-Method"
 	RestLiHeader_ProtocolVersion = "X-RestLi-Protocol-Version"
 	RestLiHeader_ErrorResponse   = "X-RestLi-Error-Response"

--- a/spec-parser/src/main/java/io/papacharlie/gorestli/MethodParser.java
+++ b/spec-parser/src/main/java/io/papacharlie/gorestli/MethodParser.java
@@ -109,6 +109,7 @@ public class MethodParser {
     method._name = name;
     method._methodType = methodType;
     method._onEntity = onEntity;
+    method._entityPathKey = _entityPathKey;
 
     if (onEntity) {
       Preconditions.checkNotNull(_entityPathKey);

--- a/spec-parser/src/main/java/io/papacharlie/gorestli/json/Method.java
+++ b/spec-parser/src/main/java/io/papacharlie/gorestli/json/Method.java
@@ -16,6 +16,7 @@ public class Method {
   public String _doc;
   public String _path;
   public boolean _onEntity;
+  public PathKey _entityPathKey;
   public List<PathKey> _pathKeys;
   public List<Field> _params;
   public RestliType _return;


### PR DESCRIPTION
Implements the `create` method with support for fetching the created object ID via `X-RestLi-Id` header.

NOTE: Does not work with complex keys