### PR TITLE
Protobuf encoding

### DIFF
--- a/internal/codegen/types/record_marshaler.go
+++ b/internal/codegen/types/record_marshaler.go
@@ -24,6 +24,16 @@ func AddMarshalRestLi(def *Statement, receiver, typeName string, f func(def *Gro
 			def.Return(Index().Byte().Call(Add(Writer.Finalize())), Nil())
 		}).Line().Line()
 
+	utils.AddFuncOnReceiver(def, receiver, typeName, "MarshalProtobuf").
+		Params().
+		Params(Id("data").Index().Byte(), Err().Error()).
+		BlockFunc(func(def *Group) {
+			def.Add(Writer).Op(":=").Qual(utils.RestLiCodecPackage, "NewProtobufWriter").Call()
+			def.Err().Op("=").Id(receiver).Dot(utils.MarshalRestLi).Call(Writer)
+			def.Add(utils.IfErrReturn(Nil(), Err()))
+			def.Return(Index().Byte().Call(Add(Writer.Finalize())), Nil())
+		}).Line().Line()
+
 	return def
 }
 

--- a/internal/codegen/types/record_unmarshaler.go
+++ b/internal/codegen/types/record_unmarshaler.go
@@ -21,6 +21,14 @@ func AddUnmarshalRestli(def *Statement, receiver, typeName string, f func(def *G
 			def.Return(Id(receiver).Dot(utils.UnmarshalRestLi).Call(Reader))
 		}).Line().Line()
 
+	utils.AddFuncOnReceiver(def, receiver, typeName, "UnmarshalProtobuf").
+		Params(Id("data").Index().Byte()).
+		Params(Error()).
+		BlockFunc(func(def *Group) {
+			def.Add(Reader).Op(":=").Add(utils.NewProtobufReader).Call(data)
+			def.Return(Id(receiver).Dot(utils.UnmarshalRestLi).Call(Reader))
+		}).Line().Line()
+
 	return def
 }
 

--- a/internal/codegen/utils/constants.go
+++ b/internal/codegen/utils/constants.go
@@ -24,8 +24,9 @@ const (
 )
 
 var (
-	NewJsonReader = Code(Qual(RestLiCodecPackage, "NewJsonReader"))
-	NewRor2Reader = Code(Qual(RestLiCodecPackage, "NewRor2Reader"))
+	NewJsonReader     = Code(Qual(RestLiCodecPackage, "NewJsonReader"))
+	NewRor2Reader     = Code(Qual(RestLiCodecPackage, "NewRor2Reader"))
+	NewProtobufReader = Code(Qual(RestLiCodecPackage, "NewProtobufReader"))
 
 	NewHash = Code(Qual(HashPackage, "NewHash").Call())
 	Hash    = Code(Qual(HashPackage, "Hash"))

--- a/internal/tests/encoding_test.go
+++ b/internal/tests/encoding_test.go
@@ -698,3 +698,34 @@ func newRor2Reader(t *testing.T, data string) restlicodec.Reader {
 }
 
 // TODO add some protobuf tests - testProtobufEncoding, testProtobufEquality, etc
+
+func TestProtobufEncoding(t *testing.T) {
+	example := &Primitives{
+		PrimitiveInteger: 1,
+		PrimitiveLong:    23,
+		PrimitiveFloat:   52.5,
+		PrimitiveDouble:  66.5,
+		PrimitiveBytes:   []byte("@ABC🕴" + string([]byte{1})),
+		PrimitiveString:  `a string,()'`,
+	}
+	// encode an "example" object into protobuf
+	writer := restlicodec.NewProtobufWriter()
+	require.NoError(t, example.MarshalRestLi(writer))
+	exampleProto := []byte(writer.Finalize())
+
+	// read object data from protobuf into new "clone" object
+	clone := &Primitives{}
+	reader := restlicodec.NewProtobufReader([]byte(writer.Finalize()))
+	require.NoError(t, clone.UnmarshalRestLi(reader))
+
+	// original "example" object should be equal to "clone"
+	require.Equal(t, example, clone)
+
+	// encode an "clone" object into protobuf
+	writer = restlicodec.NewProtobufWriter()
+	require.NoError(t, clone.MarshalRestLi(writer))
+	cloneProto := []byte(writer.Finalize())
+
+	// "example" object protobuf should be equal to "clone" object protobuf
+	require.Equal(t, exampleProto, cloneProto)
+}

--- a/internal/tests/encoding_test.go
+++ b/internal/tests/encoding_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"log"
 	"math"
@@ -38,6 +39,18 @@ func TestEncodePrimitives(t *testing.T) {
 	t.Run("ror2", func(t *testing.T) {
 		testRor2Encoding(t, expected, new(Primitives),
 			`(primitiveBytes:@ABC🕴,primitiveDouble:66.5,primitiveFloat:52.5,primitiveInteger:1,primitiveLong:23,primitiveString:a string%2C%28%29%27)`,
+		)
+	})
+
+	t.Run("protobuf", func(t *testing.T) {
+		// when vardouble floats by default
+		// testProtobufEncoding(t, expected, new(Primitives),
+		// 	"000C021C7072696D697469766542797465730A1240414243F09F95B401021E7072696D6974697665446F75626C6507808080808080A8A840021C7072696D6974697665466C6F61740680808080808090A54002207072696D6974697665496E74656765720402021A7072696D69746976654C6F6E67052E021E7072696D6974697665537472696E6702186120737472696E672C282927",
+		// )
+
+		// when fixedWidthFloat32 & fixedWidthFloat64 by default
+		testProtobufEncoding(t, expected, new(Primitives),
+			"000C021C7072696D697469766542797465730A1240414243F09F95B401021E7072696D6974697665446F75626C65160000000000A05040021C7072696D6974697665466C6F6174150000524202207072696D6974697665496E74656765720402021A7072696D69746976654C6F6E67052E021E7072696D6974697665537472696E6702186120737472696E672C282927",
 		)
 	})
 }
@@ -697,35 +710,34 @@ func newRor2Reader(t *testing.T, data string) restlicodec.Reader {
 	return reader
 }
 
-// TODO add some protobuf tests - testProtobufEncoding, testProtobufEquality, etc
+func testProtobufEncoding(t *testing.T, expected, actual protocol.RestLiObject, expectedRawBytesAsHexStr string) {
+	t.Run("encode", func(t *testing.T) {
+		testProtobufEquality(t, expected, expectedRawBytesAsHexStr, nil, true)
+	})
+	t.Run("decode", func(t *testing.T) {
+		reader := newProtobufReader(t, expectedRawBytesAsHexStr)
+		require.NoError(t, actual.UnmarshalRestLi(reader))
+		requireEqual(t, expected, actual)
+	})
+}
 
-func TestProtobufEncoding(t *testing.T) {
-	example := &Primitives{
-		PrimitiveInteger: 1,
-		PrimitiveLong:    23,
-		PrimitiveFloat:   52.5,
-		PrimitiveDouble:  66.5,
-		PrimitiveBytes:   []byte("@ABC🕴" + string([]byte{1})),
-		PrimitiveString:  `a string,()'`,
+func newProtobufReader(t *testing.T, dataAsHexStr string) restlicodec.Reader {
+	data, err := hex.DecodeString(dataAsHexStr)
+	require.NoError(t, err)
+	reader := restlicodec.NewProtobufReader(data)
+	return reader
+}
+
+func testProtobufEquality(t *testing.T, obj protocol.RestLiObject, expectedRawBytesAsHexStr string, excludedFields restlicodec.PathSpec, equal bool) {
+	writer := restlicodec.NewProtobufWriterWithExcludedFields(excludedFields)
+	require.NoError(t, obj.MarshalRestLi(writer))
+	raw := []byte(writer.Finalize())
+	// log.Printf("%X", raw) // uncomment to print current hexstr
+	expectedRaw, err := hex.DecodeString(expectedRawBytesAsHexStr)
+	require.NoError(t, err)
+	if equal {
+		require.Equal(t, expectedRaw, raw)
+	} else {
+		require.NotEqual(t, expectedRaw, raw)
 	}
-	// encode an "example" object into protobuf
-	writer := restlicodec.NewProtobufWriter()
-	require.NoError(t, example.MarshalRestLi(writer))
-	exampleProto := []byte(writer.Finalize())
-
-	// read object data from protobuf into new "clone" object
-	clone := &Primitives{}
-	reader := restlicodec.NewProtobufReader([]byte(writer.Finalize()))
-	require.NoError(t, clone.UnmarshalRestLi(reader))
-
-	// original "example" object should be equal to "clone"
-	require.Equal(t, example, clone)
-
-	// encode an "clone" object into protobuf
-	writer = restlicodec.NewProtobufWriter()
-	require.NoError(t, clone.MarshalRestLi(writer))
-	cloneProto := []byte(writer.Finalize())
-
-	// "example" object protobuf should be equal to "clone" object protobuf
-	require.Equal(t, exampleProto, cloneProto)
 }

--- a/internal/tests/encoding_test.go
+++ b/internal/tests/encoding_test.go
@@ -696,3 +696,5 @@ func newRor2Reader(t *testing.T, data string) restlicodec.Reader {
 	require.NoError(t, err)
 	return reader
 }
+
+// TODO add some protobuf tests - testProtobufEncoding, testProtobufEquality, etc

--- a/protocol/restlicodec/protobuf_reader.go
+++ b/protocol/restlicodec/protobuf_reader.go
@@ -1,0 +1,381 @@
+package restlicodec
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+)
+
+type protobufReader struct {
+	missingFieldsTracker
+	buf     *bytes.Buffer
+	started bool
+	options ProtobufOptions
+}
+
+var _ PrimitiveReader = new(protobufReader) // assert PrimitiveReader
+
+// NewProtobufReader returns a Reader that deserializes objects from a Protocol buffer encoded bytestring.
+// Ref: https://github.com/linkedin/rest.li/blob/master/data/src/main/java/com/linkedin/data/codec/ProtobufDataCodec.java
+func NewProtobufReader(data []byte) Reader {
+	p := new(protobufReader)
+	p.buf = new(bytes.Buffer)
+	p.buf.Write(data)
+	return p
+}
+
+// AtInputStart implements Reader
+func (p *protobufReader) AtInputStart() bool {
+	return !p.started
+}
+
+// ReadMap implements Reader
+func (p *protobufReader) ReadMap(mapReader MapReader) (err error) {
+	ord, err := p.ReadOrdinal()
+	if err != nil {
+		return err
+	}
+	if pbMapOrdinal != ord {
+		return &DeserializationError{
+			Err: fmt.Errorf("unexpected token in protobuf stream %v - expected %v", ord, pbMapOrdinal),
+		}
+	}
+	count, err := p.readVarint()
+	if err != nil {
+		return err
+	}
+	for i := int64(0); i < count; i++ {
+		fieldName, err := p.ReadString()
+		if err != nil {
+			return err
+		}
+		err = mapReader(p, fieldName)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadArray implements Reader
+func (p *protobufReader) ReadArray(arrayReader ArrayReader) error {
+	ord, err := p.ReadOrdinal()
+	if err != nil {
+		return err
+	}
+	if pbListOrdinal != ord {
+		return &DeserializationError{
+			Err: fmt.Errorf("unexpected token in protobuf stream %v - expected %v", ord, pbListOrdinal),
+		}
+	}
+	count, err := p.readVarint()
+	if err != nil {
+		return err
+	}
+	for i := int64(0); i < count; i++ {
+		err = arrayReader(p)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadInterface implements Reader
+func (p *protobufReader) ReadInterface() (interface{}, error) {
+	return nil, &DeserializationError{
+		Err: fmt.Errorf("this isnt finished"),
+	}
+}
+
+// ReadRawBytes implements Reader
+func (p *protobufReader) ReadRawBytes() ([]byte, error) {
+	return nil, &DeserializationError{
+		Err: fmt.Errorf("this isnt finished"),
+	}
+}
+
+// Skip implements Reader
+func (p *protobufReader) Skip() error {
+	return &DeserializationError{
+		Err: fmt.Errorf("this isnt finished"),
+	}
+}
+
+// ReadBool implements Reader
+func (p *protobufReader) ReadBool() (bool, error) {
+	v, err := p.ReadOrdinal()
+	if err != nil {
+		return false, &DeserializationError{Err: err}
+	}
+	switch v {
+	case pbBooleanTrueOrdinal:
+		return true, nil
+	case pbBooleanFalseOrdinal:
+		return false, nil
+	default:
+		return false, &DeserializationError{
+			Err: fmt.Errorf("unexpected token in protobuf stream %v - expected %v or %v", v, pbBooleanTrueOrdinal, pbBooleanFalseOrdinal),
+		}
+	}
+}
+
+// ReadInt32 implements Reader
+func (p *protobufReader) ReadInt32() (int32, error) {
+	ord, err := p.ReadOrdinal()
+	if err != nil {
+		return 0, err
+	}
+	if pbIntegerOrdinal != ord {
+		return 0, &DeserializationError{
+			Err: fmt.Errorf("unexpected token in protobuf stream %v - expected %v", ord, pbIntegerOrdinal),
+		}
+	}
+	val, err := p.readVarint()
+	return int32(val), err
+}
+
+// ReadInt64 implements Reader
+func (p *protobufReader) ReadInt64() (int64, error) {
+	ord, err := p.ReadOrdinal()
+	if err != nil {
+		return 0, err
+	}
+	if pbLongOrdinal != ord {
+		return 0, &DeserializationError{
+			Err: fmt.Errorf("unexpected token in protobuf stream %v - expected %v", ord, pbLongOrdinal),
+		}
+	}
+	val, err := p.readVarint()
+	return val, err
+}
+
+func (p *protobufReader) readVarint() (int64, error) {
+	var br io.ByteReader = p.buf
+	val, err := binary.ReadVarint(br)
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
+}
+func (p *protobufReader) readUvarint() (uint64, error) {
+	var br io.ByteReader = p.buf
+	val, err := binary.ReadUvarint(br)
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
+}
+
+// ReadFloat32 implements Reader
+func (p *protobufReader) ReadFloat32() (float32, error) {
+	ord, err := p.ReadOrdinal()
+	if err != nil {
+		return 0, err
+	}
+	if pbFloatOrdinal != ord {
+		return 0, &DeserializationError{
+			Err: fmt.Errorf("unexpected token in protobuf stream %v - expected %v", ord, pbFloatOrdinal),
+		}
+	}
+	if p.options.fixedWidthFloat32 {
+		val, err := p.readFixed32()
+		if err != nil {
+			return 0, err
+		}
+		return math.Float32frombits(val), nil
+	}
+	val, err := p.readUvarint()
+	if err != nil {
+		return 0, err
+	}
+	return math.Float32frombits(uint32(val)), nil
+}
+
+// ReadFloat64 implements Reader
+func (p *protobufReader) ReadFloat64() (float64, error) {
+	ord, err := p.ReadOrdinal()
+	if err != nil {
+		return 0, err
+	}
+	if pbDoubleOrdinal != ord {
+		return 0, &DeserializationError{
+			Err: fmt.Errorf("unexpected token in protobuf stream %v - expected %v", ord, pbDoubleOrdinal),
+		}
+	}
+	if p.options.fixedWidthFloat64 {
+		val, err := p.readFixed64()
+		if err != nil {
+			return 0, err
+		}
+		return math.Float64frombits(val), nil
+	}
+	val, err := p.readUvarint()
+	if err != nil {
+		return 0, err
+	}
+	return math.Float64frombits(uint64(val)), nil
+}
+
+func (p *protobufReader) readFixed32() (uint32, error) {
+	var (
+		err   error
+		b     byte
+		value uint32 = 0
+	)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value & uint32(b)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value & (uint32(b) << 8)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value & (uint32(b) << 16)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value & (uint32(b) << 24)
+	return value, nil
+}
+func (p *protobufReader) readFixed64() (uint64, error) {
+	var (
+		err   error
+		b     byte
+		value uint64 = 0
+	)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value & uint64(b)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value | (uint64(b) << 8)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value | (uint64(b) << 16)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value | (uint64(b) << 24)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value | (uint64(b) << 32)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value | (uint64(b) << 40)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value | (uint64(b) << 48)
+	b, err = p.buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	value = value | (uint64(b) << 56)
+	return value, nil
+}
+
+func (p *protobufReader) ReadString() (string, error) {
+	ord, err := p.ReadOrdinal()
+	if err != nil {
+		return "", err
+	}
+	if pbStringReferenceOrdinal == ord {
+		return p.readStringReference()
+	}
+	if pbStringLiteralOrdinal == ord {
+		return p.readStringLiteral()
+	}
+	return "", &DeserializationError{
+		Err: fmt.Errorf("unexpected token in protobuf stream %v - expected %v or %v", ord, pbStringLiteralOrdinal, pbStringReferenceOrdinal),
+	}
+}
+
+func (p *protobufReader) readStringLiteral() (string, error) {
+	size, err := p.readVarint()
+	if err != nil {
+		return "", err
+	}
+	var strBuf bytes.Buffer
+	for i := int64(0); i < size; i++ {
+		b, e := p.buf.ReadByte()
+		if e != nil {
+			return "", e
+		}
+		e = strBuf.WriteByte(b)
+		if e != nil {
+			return "", e
+		}
+	}
+	return strBuf.String(), nil
+}
+func (p *protobufReader) readStringReference() (string, error) {
+	val, err := p.readVarint()
+	if err != nil {
+		return "", err
+	}
+	if p.options.symbolTable == nil {
+		return "", &DeserializationError{
+			Err: fmt.Errorf("protobuf string dereference without symbolTable"),
+		}
+	}
+	symbolID := int(val)
+	symbol, found := p.options.symbolTable.GetSymbolName(symbolID)
+	if found {
+		return symbol, nil
+	}
+	return "", &DeserializationError{
+		Err: fmt.Errorf("protobuf string symbol not in symbolTable: %v", symbolID),
+	}
+}
+
+func (p *protobufReader) ReadOrdinal() (pbOrdinal, error) {
+	p.started = true
+	b, err := p.buf.ReadByte()
+	if err != nil {
+		return pbOrdinal(b), err
+	}
+	return pbOrdinal(b), err
+}
+
+func (p *protobufReader) PeakOrdinal() (pbOrdinal, error) {
+	o, e := p.ReadOrdinal()
+	if e == nil {
+		p.buf.UnreadByte()
+	}
+	return o, e
+}
+
+func (p *protobufReader) PeakByte() (byte, error) {
+	b, err := p.buf.ReadByte()
+	if err == nil {
+		p.buf.UnreadByte()
+	}
+	return b, err
+}
+
+func (p *protobufReader) ReadBytes() ([]byte, error) {
+	b := p.buf.Bytes()
+	return b, nil
+}

--- a/protocol/restlicodec/protobuf_reader.go
+++ b/protocol/restlicodec/protobuf_reader.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"math"
 )
 
@@ -153,16 +152,14 @@ func (p *protobufReader) ReadInt64() (int64, error) {
 }
 
 func (p *protobufReader) readVarint() (int64, error) {
-	var br io.ByteReader = p.buf
-	val, err := binary.ReadVarint(br)
+	val, err := binary.ReadVarint(p.buf)
 	if err != nil {
 		return 0, err
 	}
 	return val, nil
 }
 func (p *protobufReader) readUvarint() (uint64, error) {
-	var br io.ByteReader = p.buf
-	val, err := binary.ReadUvarint(br)
+	val, err := binary.ReadUvarint(p.buf)
 	if err != nil {
 		return 0, err
 	}

--- a/protocol/restlicodec/protobuf_reader.go
+++ b/protocol/restlicodec/protobuf_reader.go
@@ -226,22 +226,22 @@ func (p *protobufReader) readFixed32() (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	value = value & uint32(b)
+	value = value | uint32(b)
 	b, err = p.buf.ReadByte()
 	if err != nil {
 		return 0, err
 	}
-	value = value & (uint32(b) << 8)
+	value = value | (uint32(b) << 8)
 	b, err = p.buf.ReadByte()
 	if err != nil {
 		return 0, err
 	}
-	value = value & (uint32(b) << 16)
+	value = value | (uint32(b) << 16)
 	b, err = p.buf.ReadByte()
 	if err != nil {
 		return 0, err
 	}
-	value = value & (uint32(b) << 24)
+	value = value | (uint32(b) << 24)
 	return value, nil
 }
 func (p *protobufReader) readFixed64() (uint64, error) {

--- a/protocol/restlicodec/protobuf_reader.go
+++ b/protocol/restlicodec/protobuf_reader.go
@@ -177,7 +177,7 @@ func (p *protobufReader) ReadFloat32() (float32, error) {
 		if err != nil {
 			return 0, err
 		}
-		return math.Float32frombits(uint32(val)), nil
+		return float32(math.Float64frombits(val)), nil
 	}
 	if pbFixedFloatOrdinal == ord {
 		val, err := p.readFixed32()
@@ -189,7 +189,6 @@ func (p *protobufReader) ReadFloat32() (float32, error) {
 	return 0, &DeserializationError{
 		Err: fmt.Errorf("unexpected token in protobuf stream %v - expected %v", ord, pbFloatOrdinal),
 	}
-
 }
 
 // ReadFloat64 implements Reader

--- a/protocol/restlicodec/protobuf_symboltable.go
+++ b/protocol/restlicodec/protobuf_symboltable.go
@@ -1,0 +1,35 @@
+package restlicodec
+
+type SymbolTable interface {
+	GetSymbolId(symbolName string) (int, bool)
+	GetSymbolName(symbolId int) (string, bool)
+}
+
+type genericSymbolTable struct {
+	byName map[string]int
+	byID   map[int]string
+	size   int
+}
+
+// TODO this probably isn't right
+func NewSymbolTable(symbols []string) SymbolTable {
+	table := &genericSymbolTable{
+		byName: make(map[string]int),
+		byID:   make(map[int]string),
+	}
+	for _, v := range symbols {
+		table.byID[table.size] = v
+		table.byName[v] = table.size
+		table.size++
+	}
+	return table
+}
+
+func (t *genericSymbolTable) GetSymbolId(symbolName string) (int, bool) {
+	i, f := t.byName[symbolName]
+	return i, f
+}
+func (t *genericSymbolTable) GetSymbolName(symbolId int) (string, bool) {
+	s, f := t.byID[symbolId]
+	return s, f
+}

--- a/protocol/restlicodec/protobuf_writer.go
+++ b/protocol/restlicodec/protobuf_writer.go
@@ -95,6 +95,18 @@ func makeProtobufWriter() *protobufWriter {
 	return out
 }
 
+func (p ProtobufOptions) NewProtobufWriter() WriteCloser {
+	out := makeProtobufWriter()
+	out.options = p
+	return out
+}
+func (p ProtobufOptions) NewProtobufWriterWithExcludedFields(excludedFields PathSpec) WriteCloser {
+	out := makeProtobufWriter()
+	out.excludedFields = excludedFields
+	out.options = p
+	return out
+}
+
 func (p *protobufWriter) subWriter(key string) *protobufWriter {
 	var out protobufWriter
 	out = *p

--- a/protocol/restlicodec/protobuf_writer.go
+++ b/protocol/restlicodec/protobuf_writer.go
@@ -1,0 +1,123 @@
+package restlicodec
+
+import (
+	"bytes"
+	"io"
+)
+
+type protobufWriter struct {
+	bytes.Buffer
+}
+
+const (
+	pbMapOrdinal                  = '\x00'
+	pbListOrdinal                 = '\x01'
+	pbString_literalOrdinal       = '\x02'
+	pbStringReferenceOrdinal      = '\x03'
+	pbIntegerOrdinal              = '\x04'
+	pbLongOrdinal                 = '\x05'
+	pbFloatOrdinal                = '\x06'
+	pbDoubleOrdinal               = '\x07'
+	pbBooleanTrueOrdinal          = '\x08'
+	pbBooleanFalseOrdinal         = '\x09'
+	pbRawBytesOrdinal             = '\x0A'
+	pbNullOrdinal                 = '\x0B'
+	pbAscii_string_literalOrdinal = '\x14'
+	pbFixed_floatOrdinal          = '\x15'
+	pbFixed_doubleOrdinal         = '\x16'
+	pbSerializeFixedFloats        = "serialize_fixed_floats"
+	pbSymbolTableParamName        = "symbol-table"
+)
+
+var _ PrimitiveWriter = new(protobufWriter)
+var _ Writer = new(protobufWriter)
+var _ WriteCloser = new(protobufWriter)
+var _ rawWriter = new(protobufWriter)
+
+// NewProtobufWriter returns a WriteCloser that serializes objects using a Protocol buffer encoder.
+// https://github.com/linkedin/rest.li/blob/master/data/src/main/java/com/linkedin/data/codec/ProtobufDataCodec.java
+func NewProtobufWriter() WriteCloser {
+	return newGenericWriter(new(protobufWriter), nil)
+}
+
+// PrimitiveWriter
+
+func (c *protobufWriter) writeMapStart() {
+	c.WriteOrdinal(pbMapOrdinal)
+	// somehow need to output length before it is known
+}
+
+func (c *protobufWriter) writeKey(key string) {
+	c.WriteString(key)
+}
+
+func (c *protobufWriter) writeKeyDelimiter()   {} // no key delimiter
+func (c *protobufWriter) writeEntryDelimiter() {} // no entry delimiter
+func (c *protobufWriter) writeMapEnd()         {} // no end marker
+
+func (c *protobufWriter) writeArrayStart() {
+	c.WriteOrdinal(pbListOrdinal)
+	// somehow need to output length before it is known
+}
+
+func (c *protobufWriter) writeArrayItemDelimiter() {} // no array item delimiter
+
+func (c *protobufWriter) writeArrayEnd() {} // no end marker
+
+func (c *protobufWriter) WriteBool(v bool) {
+	if v {
+		c.WriteOrdinal(pbBooleanTrueOrdinal)
+	} else {
+		c.WriteOrdinal(pbBooleanFalseOrdinal)
+	}
+}
+
+func (c *protobufWriter) WriteInt32(v int32) {
+	// c.WriteVarInt(int64(v))
+}
+func (c *protobufWriter) WriteInt64(v int64) {
+	// c.WriteVarInt(v)
+}
+func (c *protobufWriter) WriteFloat32(v float32) {
+	// c.WriteVarDouble(float64(v))
+}
+func (c *protobufWriter) WriteFloat64(v float64) {
+	// c.WriteVarDouble(v)
+}
+func (c *protobufWriter) WriteString(v string) {
+	// if v in symbol_table
+	// c.WriteOrdinal(pbStringReferenceOrdinal)
+	// c.WriteVarInt(symbol_id)
+
+}
+
+// WriteBytes
+func (c *protobufWriter) WriteBytes(v []byte) {
+	c.WriteOrdinal(pbRawBytesOrdinal)
+	c.WriteVarInt(int64(len(v)))
+	c.Buffer.Write(v)
+}
+
+func (c *protobufWriter) WriteOrdinal(v byte) {
+	c.Buffer.WriteByte(v)
+}
+
+// The following are exposed directly by jwriter.Writer
+func (c *protobufWriter) RawByte(v byte) {
+	c.Buffer.WriteByte(v)
+}
+func (c *protobufWriter) Raw(v []byte, _ error) {
+	c.Buffer.Write(v)
+}
+func (c *protobufWriter) RawString(v string) {
+	c.Buffer.WriteString(v)
+}
+func (c *protobufWriter) BuildBytes(...[]byte) ([]byte, error) {}
+func (c *protobufWriter) ReadCloser() (io.ReadCloser, error)   {}
+func (c *protobufWriter) Size() int {
+	return c.Buffer.Len()
+}
+
+//  https://developers.google.com/protocol-buffers/docs/encoding#varints
+func (c *protobufWriter) WriteVarInt(v int64)      {}
+func (c *protobufWriter) WriteVarDouble(v float64) {}

--- a/protocol/restlicodec/protobuf_writer.go
+++ b/protocol/restlicodec/protobuf_writer.go
@@ -2,142 +2,275 @@ package restlicodec
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 	"io/ioutil"
+	"math"
 )
 
 type protobufWriter struct {
-	bytes.Buffer
+	excludedFields PathSpec
+	scope          []string
+	options        protobufWriterOptions
+	buf            *bytes.Buffer
+}
+type protobufWriterOptions struct {
+	symbolTable       SymbolTable
+	fixedWidthFloat32 bool
+	fixedWidthFloat64 bool
 }
 
+type pbOrdinal byte
+
 const (
-	pbMapOrdinal                = '\x00'
-	pbListOrdinal               = '\x01'
-	pbStringLiteralOrdinal      = '\x02'
-	pbStringReferenceOrdinal    = '\x03'
-	pbIntegerOrdinal            = '\x04'
-	pbLongOrdinal               = '\x05'
-	pbFloatOrdinal              = '\x06'
-	pbDoubleOrdinal             = '\x07'
-	pbBooleanTrueOrdinal        = '\x08'
-	pbBooleanFalseOrdinal       = '\x09'
-	pbRawBytesOrdinal           = '\x0A'
-	pbNullOrdinal               = '\x0B'
-	pbASCIIStringLiteralOrdinal = '\x14'
-	pbFixedFloatOrdinal         = '\x15'
-	pbFixedDoubleOrdinal        = '\x16'
-	pbSerializeFixedFloats      = "serialize_fixed_floats"
-	pbSymbolTableParamName      = "symbol-table"
+	pbMapOrdinal                pbOrdinal = '\x00'
+	pbListOrdinal               pbOrdinal = '\x01'
+	pbStringLiteralOrdinal      pbOrdinal = '\x02'
+	pbStringReferenceOrdinal    pbOrdinal = '\x03'
+	pbIntegerOrdinal            pbOrdinal = '\x04'
+	pbLongOrdinal               pbOrdinal = '\x05'
+	pbFloatOrdinal              pbOrdinal = '\x06'
+	pbDoubleOrdinal             pbOrdinal = '\x07'
+	pbBooleanTrueOrdinal        pbOrdinal = '\x08'
+	pbBooleanFalseOrdinal       pbOrdinal = '\x09'
+	pbRawBytesOrdinal           pbOrdinal = '\x0A'
+	pbNullOrdinal               pbOrdinal = '\x0B'
+	pbASCIIStringLiteralOrdinal pbOrdinal = '\x14'
+	pbFixedFloatOrdinal         pbOrdinal = '\x15'
+	pbFixedDoubleOrdinal        pbOrdinal = '\x16'
 )
 
+// TODO remove these type assertions
 var _ PrimitiveWriter = new(protobufWriter) // assert PrimitiveWriter
-var _ Writer = NewProtobufWriter()          // assert Writer
-var _ WriteCloser = NewProtobufWriter()     // assert WriteCloser
-var _ rawWriter = new(protobufWriter)       // assert rawWriter
+var _ Writer = new(protobufWriter)          // assert Writer
+var _ WriteCloser = new(protobufWriter)     // assert WriteCloser
 
 // NewProtobufWriter returns a WriteCloser that serializes objects using a Protocol buffer encoder modeled after this codec:
 // https://github.com/linkedin/rest.li/blob/master/data/src/main/java/com/linkedin/data/codec/ProtobufDataCodec.java
 func NewProtobufWriter() WriteCloser {
-	return newGenericWriter(new(protobufWriter), nil)
+	out := new(protobufWriter)
+	out.buf = new(bytes.Buffer)
+	return out
 }
 
 // NewProtobufWriterWithExcludedFields returns a WriteCloser as from NewProtobufWriter(), excluding any fields matched by the given PathSpec.
 func NewProtobufWriterWithExcludedFields(excludedFields PathSpec) WriteCloser {
-	return newGenericWriter(new(protobufWriter), excludedFields)
+	out := new(protobufWriter)
+	out.buf = new(bytes.Buffer)
+	out.excludedFields = excludedFields
+	return out
 }
 
-func (c *protobufWriter) writeMapStart() {
-	c.WriteOrdinal(pbMapOrdinal)
-	// somehow need to output length before it is known
+func (p *protobufWriter) subWriter(key string) *protobufWriter {
+	var out protobufWriter
+	out = *p
+	out.scope = copyAndAppend(p.scope, key)
+	return &out
+}
+func (p *protobufWriter) pushBuffer() *bytes.Buffer {
+	old := p.buf
+	p.buf = new(bytes.Buffer)
+	return old
+}
+func (p *protobufWriter) swapBuffer(next *bytes.Buffer) *bytes.Buffer {
+	prev := p.buf
+	p.buf = next
+	return prev
 }
 
-func (c *protobufWriter) writeKey(key string) {
-	c.WriteString(key)
+func (p *protobufWriter) WriteMap(mapWriter MapWriter) (err error) {
+	tmpBuffer := p.pushBuffer()
+
+	var count int64
+	sub := p.subWriter("")
+
+	defer func() {
+		tmpBuffer = p.swapBuffer(tmpBuffer)
+		p.WriteOrdinal(pbMapOrdinal)
+		p.WriteVarint(count)
+		if count > 0 {
+			p.WriteRawBytes(tmpBuffer.Bytes())
+		}
+	}()
+
+	err = mapWriter(func(key string) Writer {
+		if p.IsKeyExcluded(key) {
+			return noopWriter
+		}
+		count++
+		p.WriteString(key)
+		sub.scope[len(sub.scope)-1] = key
+		var writer Writer = sub
+		return writer
+	})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-func (c *protobufWriter) writeKeyDelimiter()   {} // no key delimiter
-func (c *protobufWriter) writeEntryDelimiter() {} // no entry delimiter
-func (c *protobufWriter) writeMapEnd()         {} // no end marker
+func (p *protobufWriter) WriteArray(arrayWriter ArrayWriter) (err error) {
+	tmpBuffer := p.pushBuffer()
+	var count int64
+	sub := p.subWriter(WildCard)
 
-func (c *protobufWriter) writeArrayStart() {
-	c.WriteOrdinal(pbListOrdinal)
-	// somehow need to output length before it is known
+	defer func() {
+		tmpBuffer = p.swapBuffer(tmpBuffer)
+		p.WriteOrdinal(pbListOrdinal)
+		p.WriteVarint(count)
+		if count > 0 {
+			p.WriteRawBytes(tmpBuffer.Bytes())
+		}
+	}()
+
+	err = arrayWriter(func() Writer {
+		return sub
+	})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-func (c *protobufWriter) writeArrayItemDelimiter() {} // no array item delimiter
+// IsKeyExcluded implements Writer
+func (p *protobufWriter) IsKeyExcluded(key string) bool {
+	p.scope = append(p.scope, key)
+	excluded := p.excludedFields.Matches(p.scope)
+	p.scope = p.scope[:len(p.scope)-1]
+	return excluded
+}
 
-func (c *protobufWriter) writeArrayEnd() {} // no end marker
+// SetScope implements Writer
+func (p *protobufWriter) SetScope(scope ...string) Writer {
+	var out protobufWriter
+	out = *p
+	out.scope = scope
+	return &out
+}
 
-func (c *protobufWriter) WriteBool(v bool) {
+func (p *protobufWriter) WriteBool(v bool) {
 	if v {
-		c.WriteOrdinal(pbBooleanTrueOrdinal)
+		p.WriteOrdinal(pbBooleanTrueOrdinal)
 	} else {
-		c.WriteOrdinal(pbBooleanFalseOrdinal)
+		p.WriteOrdinal(pbBooleanFalseOrdinal)
 	}
 }
 
 // WriteInt32 implements PrimitiveWriter
-func (c *protobufWriter) WriteInt32(v int32) {
-	c.WriteOrdinal(pbIntegerOrdinal)
-	c.WriteVarInt(int64(v))
+func (p *protobufWriter) WriteInt32(v int32) {
+	p.WriteOrdinal(pbIntegerOrdinal)
+	p.WriteVarint(int64(v))
 }
 
 // WriteInt64 implements PrimitiveWriter
-func (c *protobufWriter) WriteInt64(v int64) {
-	c.WriteOrdinal(pbLongOrdinal)
-	c.WriteVarInt(v)
+func (p *protobufWriter) WriteInt64(v int64) {
+	p.WriteOrdinal(pbLongOrdinal)
+	p.WriteVarint(v)
 }
 
 // WriteFloat32 implements PrimitiveWriter
-func (c *protobufWriter) WriteFloat32(v float32) {
-	c.WriteOrdinal(pbFloatOrdinal)
-	c.WriteVarDouble(float64(v))
+func (p *protobufWriter) WriteFloat32(v float32) {
+	if p.options.fixedWidthFloat32 {
+		p.WriteOrdinal(pbFixedFloatOrdinal)
+		p.writeFixed32(uint32(math.Float64bits(float64(v))))
+	} else {
+		p.WriteOrdinal(pbFloatOrdinal)
+		p.WriteVarDouble(float64(v))
+	}
 }
 
 // WriteFloat64 implements PrimitiveWriter
-func (c *protobufWriter) WriteFloat64(v float64) {
-	c.WriteOrdinal(pbDoubleOrdinal)
-	c.WriteVarDouble(v)
+func (p *protobufWriter) WriteFloat64(v float64) {
+	if p.options.fixedWidthFloat32 {
+		p.WriteOrdinal(pbFixedDoubleOrdinal)
+		p.writeFixed64(math.Float64bits(float64(v)))
+	} else {
+		p.WriteOrdinal(pbDoubleOrdinal)
+		p.WriteVarDouble(v)
+	}
 }
-func (c *protobufWriter) WriteString(v string) {
-	// TODO add string symbol table (pbStringReferenceOrdinal)
-	c.WriteOrdinal(pbStringLiteralOrdinal)
+
+func (p *protobufWriter) WriteString(v string) {
+	if p.options.symbolTable != nil {
+		id, found := p.options.symbolTable.GetSymbolId(v)
+		if found {
+			p.WriteOrdinal(pbStringReferenceOrdinal)
+			p.WriteVarint(int64(id))
+			return
+		}
+	}
+	p.WriteOrdinal(pbStringLiteralOrdinal)
 	b := []byte(v)
-	c.WriteVarInt(int64(len(b)))
-	c.Buffer.Write(b)
+	p.WriteVarint(int64(len(b)))
+	p.buf.Write(b)
 }
 
 // WriteBytes implements PrimitiveWriter
-func (c *protobufWriter) WriteBytes(v []byte) {
-	c.WriteOrdinal(pbRawBytesOrdinal)
-	c.WriteVarInt(int64(len(v)))
-	c.Buffer.Write(v)
+func (p *protobufWriter) WriteBytes(v []byte) {
+	p.WriteOrdinal(pbRawBytesOrdinal)
+	p.WriteVarint(int64(len(v)))
+	p.buf.Write(v)
 }
 
 // WriteOrdinal writes the given ordinal byte to the buffer
-func (c *protobufWriter) WriteOrdinal(v byte) {
-	c.Buffer.WriteByte(v)
+func (p *protobufWriter) WriteOrdinal(v pbOrdinal) {
+	p.buf.WriteByte(byte(v))
 }
 
-func (c *protobufWriter) RawByte(v byte) {
-	c.Buffer.WriteByte(v)
+func (p *protobufWriter) RawByte(v byte) {
+	p.buf.WriteByte(v)
 }
-func (c *protobufWriter) Raw(v []byte, _ error) {
-	c.Buffer.Write(v)
+func (p *protobufWriter) Raw(v []byte, _ error) {
+	p.buf.Write(v)
 }
-func (c *protobufWriter) RawString(v string) {
-	c.Buffer.WriteString(v)
+func (p *protobufWriter) RawString(v string) {
+	p.buf.WriteString(v)
 }
-func (c *protobufWriter) BuildBytes(...[]byte) ([]byte, error) {
-	return c.Buffer.Bytes(), nil
+func (p *protobufWriter) WriteRawBytes(data []byte) {
+	p.Raw(data, nil)
 }
-func (c *protobufWriter) ReadCloser() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewReader(c.Buffer.Bytes())), nil
+func (p *protobufWriter) BuildBytes(...[]byte) ([]byte, error) {
+	return p.buf.Bytes(), nil
 }
-func (c *protobufWriter) Size() int {
-	return c.Buffer.Len()
+func (p *protobufWriter) ReadCloser() io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader(p.buf.Bytes()))
+}
+func (p *protobufWriter) Size() int {
+	return p.buf.Len()
+}
+func (p *protobufWriter) Finalize() string {
+	data, _ := p.BuildBytes()
+	return string(data)
 }
 
 //  https://developers.google.com/protocol-buffers/docs/encoding#varints
-func (c *protobufWriter) WriteVarInt(v int64)      {}
-func (c *protobufWriter) WriteVarDouble(v float64) {}
+func (p *protobufWriter) WriteVarint(v int64) {
+	var buf []byte = make([]byte, 4)
+	s := binary.PutVarint(buf, 4)
+	p.WriteRawBytes(buf[:s])
+}
+func (p *protobufWriter) WriteUvarint(v uint64) {
+	var buf []byte = make([]byte, 4)
+	s := binary.PutUvarint(buf, 4)
+	p.WriteRawBytes(buf[:s])
+}
+func (p *protobufWriter) WriteVarDouble(v float64) {
+	uintBits := math.Float64bits(v)
+	p.WriteUvarint(uintBits)
+}
+func (p *protobufWriter) writeFixed32(value uint32) {
+	p.buf.WriteByte(byte(value & 0xFF))
+	p.buf.WriteByte(byte((value >> 8) & 0xFF))
+	p.buf.WriteByte(byte((value >> 16) & 0xFF))
+	p.buf.WriteByte(byte((value >> 24) & 0xFF))
+}
+func (p *protobufWriter) writeFixed64(value uint64) {
+	p.buf.WriteByte(byte(value & 0xFF))
+	p.buf.WriteByte(byte((value >> 8) & 0xFF))
+	p.buf.WriteByte(byte((value >> 16) & 0xFF))
+	p.buf.WriteByte(byte((value >> 24) & 0xFF))
+	p.buf.WriteByte(byte((value >> 32) & 0xFF))
+	p.buf.WriteByte(byte((value >> 40) & 0xFF))
+	p.buf.WriteByte(byte((value >> 48) & 0xFF))
+	p.buf.WriteByte(byte((value >> 56) & 0xFF))
+}

--- a/protocol/restlicodec/protobuf_writer.go
+++ b/protocol/restlicodec/protobuf_writer.go
@@ -3,6 +3,7 @@ package restlicodec
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 )
 
 type protobufWriter struct {
@@ -10,37 +11,40 @@ type protobufWriter struct {
 }
 
 const (
-	pbMapOrdinal                  = '\x00'
-	pbListOrdinal                 = '\x01'
-	pbString_literalOrdinal       = '\x02'
-	pbStringReferenceOrdinal      = '\x03'
-	pbIntegerOrdinal              = '\x04'
-	pbLongOrdinal                 = '\x05'
-	pbFloatOrdinal                = '\x06'
-	pbDoubleOrdinal               = '\x07'
-	pbBooleanTrueOrdinal          = '\x08'
-	pbBooleanFalseOrdinal         = '\x09'
-	pbRawBytesOrdinal             = '\x0A'
-	pbNullOrdinal                 = '\x0B'
-	pbAscii_string_literalOrdinal = '\x14'
-	pbFixed_floatOrdinal          = '\x15'
-	pbFixed_doubleOrdinal         = '\x16'
-	pbSerializeFixedFloats        = "serialize_fixed_floats"
-	pbSymbolTableParamName        = "symbol-table"
+	pbMapOrdinal                = '\x00'
+	pbListOrdinal               = '\x01'
+	pbStringLiteralOrdinal      = '\x02'
+	pbStringReferenceOrdinal    = '\x03'
+	pbIntegerOrdinal            = '\x04'
+	pbLongOrdinal               = '\x05'
+	pbFloatOrdinal              = '\x06'
+	pbDoubleOrdinal             = '\x07'
+	pbBooleanTrueOrdinal        = '\x08'
+	pbBooleanFalseOrdinal       = '\x09'
+	pbRawBytesOrdinal           = '\x0A'
+	pbNullOrdinal               = '\x0B'
+	pbASCIIStringLiteralOrdinal = '\x14'
+	pbFixedFloatOrdinal         = '\x15'
+	pbFixedDoubleOrdinal        = '\x16'
+	pbSerializeFixedFloats      = "serialize_fixed_floats"
+	pbSymbolTableParamName      = "symbol-table"
 )
 
-var _ PrimitiveWriter = new(protobufWriter)
-var _ Writer = new(protobufWriter)
-var _ WriteCloser = new(protobufWriter)
-var _ rawWriter = new(protobufWriter)
+var _ PrimitiveWriter = new(protobufWriter) // assert PrimitiveWriter
+var _ Writer = NewProtobufWriter()          // assert Writer
+var _ WriteCloser = NewProtobufWriter()     // assert WriteCloser
+var _ rawWriter = new(protobufWriter)       // assert rawWriter
 
-// NewProtobufWriter returns a WriteCloser that serializes objects using a Protocol buffer encoder.
+// NewProtobufWriter returns a WriteCloser that serializes objects using a Protocol buffer encoder modeled after this codec:
 // https://github.com/linkedin/rest.li/blob/master/data/src/main/java/com/linkedin/data/codec/ProtobufDataCodec.java
 func NewProtobufWriter() WriteCloser {
 	return newGenericWriter(new(protobufWriter), nil)
 }
 
-// PrimitiveWriter
+// NewProtobufWriterWithExcludedFields returns a WriteCloser as from NewProtobufWriter(), excluding any fields matched by the given PathSpec.
+func NewProtobufWriterWithExcludedFields(excludedFields PathSpec) WriteCloser {
+	return newGenericWriter(new(protobufWriter), excludedFields)
+}
 
 func (c *protobufWriter) writeMapStart() {
 	c.WriteOrdinal(pbMapOrdinal)
@@ -72,37 +76,49 @@ func (c *protobufWriter) WriteBool(v bool) {
 	}
 }
 
+// WriteInt32 implements PrimitiveWriter
 func (c *protobufWriter) WriteInt32(v int32) {
-	// c.WriteVarInt(int64(v))
+	c.WriteOrdinal(pbIntegerOrdinal)
+	c.WriteVarInt(int64(v))
 }
+
+// WriteInt64 implements PrimitiveWriter
 func (c *protobufWriter) WriteInt64(v int64) {
-	// c.WriteVarInt(v)
+	c.WriteOrdinal(pbLongOrdinal)
+	c.WriteVarInt(v)
 }
+
+// WriteFloat32 implements PrimitiveWriter
 func (c *protobufWriter) WriteFloat32(v float32) {
-	// c.WriteVarDouble(float64(v))
+	c.WriteOrdinal(pbFloatOrdinal)
+	c.WriteVarDouble(float64(v))
 }
+
+// WriteFloat64 implements PrimitiveWriter
 func (c *protobufWriter) WriteFloat64(v float64) {
-	// c.WriteVarDouble(v)
+	c.WriteOrdinal(pbDoubleOrdinal)
+	c.WriteVarDouble(v)
 }
 func (c *protobufWriter) WriteString(v string) {
-	// if v in symbol_table
-	// c.WriteOrdinal(pbStringReferenceOrdinal)
-	// c.WriteVarInt(symbol_id)
-
+	// TODO add string symbol table (pbStringReferenceOrdinal)
+	c.WriteOrdinal(pbStringLiteralOrdinal)
+	b := []byte(v)
+	c.WriteVarInt(int64(len(b)))
+	c.Buffer.Write(b)
 }
 
-// WriteBytes
+// WriteBytes implements PrimitiveWriter
 func (c *protobufWriter) WriteBytes(v []byte) {
 	c.WriteOrdinal(pbRawBytesOrdinal)
 	c.WriteVarInt(int64(len(v)))
 	c.Buffer.Write(v)
 }
 
+// WriteOrdinal writes the given ordinal byte to the buffer
 func (c *protobufWriter) WriteOrdinal(v byte) {
 	c.Buffer.WriteByte(v)
 }
 
-// The following are exposed directly by jwriter.Writer
 func (c *protobufWriter) RawByte(v byte) {
 	c.Buffer.WriteByte(v)
 }
@@ -112,8 +128,12 @@ func (c *protobufWriter) Raw(v []byte, _ error) {
 func (c *protobufWriter) RawString(v string) {
 	c.Buffer.WriteString(v)
 }
-func (c *protobufWriter) BuildBytes(...[]byte) ([]byte, error) {}
-func (c *protobufWriter) ReadCloser() (io.ReadCloser, error)   {}
+func (c *protobufWriter) BuildBytes(...[]byte) ([]byte, error) {
+	return c.Buffer.Bytes(), nil
+}
+func (c *protobufWriter) ReadCloser() (io.ReadCloser, error) {
+	return ioutil.NopCloser(bytes.NewReader(c.Buffer.Bytes())), nil
+}
 func (c *protobufWriter) Size() int {
 	return c.Buffer.Len()
 }

--- a/protocol/restlicodec/protobuf_writer.go
+++ b/protocol/restlicodec/protobuf_writer.go
@@ -90,8 +90,8 @@ func NewProtobufWriterWithExcludedFields(excludedFields PathSpec) WriteCloser {
 func makeProtobufWriter() *protobufWriter {
 	out := new(protobufWriter)
 	out.buf = new(bytes.Buffer)
-	out.options.fixedWidthFloat32 = false
-	out.options.fixedWidthFloat64 = false
+	out.options.fixedWidthFloat32 = true
+	out.options.fixedWidthFloat64 = true
 	return out
 }
 

--- a/protocol/restlicodec/reader.go
+++ b/protocol/restlicodec/reader.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-// Unmarshaler is the interface that should be implemented by objects that can be deserialized from JSON and ROR2
+// Unmarshaler is the interface that should be implemented by objects that can be deserialized from JSON and ROR2 and Protobuf
 type Unmarshaler interface {
 	UnmarshalRestLi(Reader) error
 }

--- a/protocol/restlicodec/writer.go
+++ b/protocol/restlicodec/writer.go
@@ -4,7 +4,7 @@ import (
 	"io"
 )
 
-// Marshaler is the interface that should be implemented by objects that can be serialized to JSON and ROR2
+// Marshaler is the interface that should be implemented by objects that can be serialized to JSON and ROR2 and Protobuf
 type Marshaler interface {
 	MarshalRestLi(Writer) error
 }

--- a/protocol/restlicodec/writer.go
+++ b/protocol/restlicodec/writer.go
@@ -4,7 +4,7 @@ import (
 	"io"
 )
 
-// Unmarshaler is the interface that should be implemented by objects that can be serialized to JSON and ROR2
+// Marshaler is the interface that should be implemented by objects that can be serialized to JSON and ROR2
 type Marshaler interface {
 	MarshalRestLi(Writer) error
 }


### PR DESCRIPTION
Adds protobuf encoder and decoder based on specification: https://github.com/linkedin/rest.li/blob/master/data/src/main/java/com/linkedin/data/codec/ProtobufDataCodec.java

- [x] ~Needs tests.~ it would be nice to have relevant tests against submoduled restli-test-suite
- [ ] The wiring within internal/codegen needs a good second look.
- [ ] The wiring to http calls isn't done.
- [X] ~Currently no way to provide a custom `SymbolTable` or `ProtobufOptions`.~