### PR TITLE
Add dependencies in README and update the maven repo for restli-tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,13 @@ func (s *TestServer) CollectionGet(t *testing.T, c *Client) {
 }
 ```
 Once you have written your tests, just run `make` in the root directory and all the tests will be run.
+
+
+## Building from source
+
+This project uses ``make`` as the build tool and requires following dependencies:
+
+* Golang
+* Java 1.8+
+* ``goimports``
+* ``stringer``

--- a/spec-parser/build.gradle
+++ b/spec-parser/build.gradle
@@ -8,7 +8,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven {
-        url "https://linkedin.jfrog.io/artifactory/maven-bintray-temp"
+        url "https://linkedin.jfrog.io/artifactory/open-source"
     }
     mavenCentral()
   }

--- a/spec-parser/build.gradle
+++ b/spec-parser/build.gradle
@@ -8,7 +8,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven {
-        url "https://linkedin.bintray.com/maven"
+        url "https://linkedin.jfrog.io/artifactory/maven-bintray-temp"
     }
     mavenCentral()
   }

--- a/spec-parser/gradle.properties
+++ b/spec-parser/gradle.properties
@@ -1,1 +1,1 @@
-pegasusVersion=29.12.0
+pegasusVersion=29.18.1


### PR DESCRIPTION
Now that Bintray has been deprecated and rest-li team has moved on to Jfrog for publishing the restli-tools, update the URLs in this proejct.